### PR TITLE
Include stdlib.h in offsetfinder.c

### DIFF
--- a/ibootpatch2/offsetfinder.c
+++ b/ibootpatch2/offsetfinder.c
@@ -11,6 +11,7 @@
 //  Copyright (c) 2021 sakuRdev. All rights reserved.
 //
 
+#include <stdlib.h>
 #include <stdint.h>
 #include "offsetfinder.h"
 


### PR DESCRIPTION
On some platforms, such as glibc platforms, NULL do not get defined unless this header is included